### PR TITLE
Fix empty location string meaning / instead of current path

### DIFF
--- a/src/Components/AccuracyLeaderboard/AccuracyLeaderboard.tsx
+++ b/src/Components/AccuracyLeaderboard/AccuracyLeaderboard.tsx
@@ -58,9 +58,11 @@ function useQueryParams() {
 				}
 			});
 			const newParamsString = newParams.toString();
-			history.push(newParamsString ? `?${newParamsString}` : '');
+			const newLocation = location.pathname +
+				(newParamsString ? `?${newParamsString}` : '');
+			history.push(newLocation);
 		},
-		[history, location.search]
+		[history, location.pathname, location.search]
 	);
 
 	return [queryParams, setQueryParams];


### PR DESCRIPTION
I assumed that `history.push("")` would be like having a link with `href=""` – it would just mean the current page with no query params.

Instead it means `/`.