### PR TITLE
Add grenade launcher stats to accuracy leaderboard

### DIFF
--- a/src/Components/AccuracyLeaderboard/AccuracyLeaderboard.tsx
+++ b/src/Components/AccuracyLeaderboard/AccuracyLeaderboard.tsx
@@ -28,6 +28,9 @@ const statOptions = {
 	laserHitsTG: { label: 'laser hits' },
 	cgHitsTG: { label: 'chaingun hits' },
 	shockHitsTG: { label: 'shocklance hits' },
+	grenadeMATG: { label: 'grenade MAs' },
+	grenadeHitsTG: { label: 'grenade hits (direct)' },
+	grenadeDmgHitsTG: { label: 'grenade hits (incl. splash)' },
 } as const;
 
 const gameTypeOptions = {


### PR DESCRIPTION
(Requires `t2-stat-parser` updates to be deployed.)